### PR TITLE
Option to upload 10X files or a single matrix file

### DIFF
--- a/Single-Cell RNA-seq Clustering Analysis Notebook.ipynb
+++ b/Single-Cell RNA-seq Clustering Analysis Notebook.ipynb
@@ -62,17 +62,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<p>Load a raw count matrix for a single-cell RNA-seq experiment. </p>\n",
+    "Load raw count data for a single-cell RNA-seq experiment.\n",
     "\n",
-    "<p><b>Supported file formats</b>: `csv`, `txt`, `tsv`, `tab`, `data`, `h5`, `h5ad`, `loom`, `mtx*`</p>\n",
+    "This notebook accepts either a single matrix file that includes gene and cell identifiers (as the first column and row respectively) or the three-file output from the 10X Genomics single-cell pipeline.\n",
     "\n",
-    "<p><b>Text and Excel files</b> (csv, txt, tsv, tab, data): Gene and sample names are assumed to be the first column and row respectively.</p>\n",
-    "\n",
-    "<p><b>NOTE</b>: The 10x Genomics genomics pipeline generates gene-barcode matrices usually named `matrix.mtx`, `genes.tsv`, and `barcodes.tsv`. If the `mtx` files is provided, the genes and barcodes files will autoomatically be imported from the same folder.</p>\n",
+    "The single matrix file can be in the following formats: `csv`, `txt`, `tsv`, `tab`, `data`, `h5`, `h5ad`, `loom`\n",
     "\n",
     "<div class=\"alert alert-info\">\n",
-    "<h3 style=\"margin-top: 0;\"> Instructions <i class=\"fa fa-info-circle\"></i></h3>\n",
-    "<ol><li>Provide your data file either as a URL or local file path. Select \"2700 PBMCs from a Healthy Donor (example)\" from the dropdown menu to load the example dataset.</li></ol>\n",
+    "    <h3 style=\"margin-top: 0;\"> Instructions <i class=\"fa fa-info-circle\"></i></h3>\n",
+    "    <ol>\n",
+    "        <li>If you have a single matrix file that includes gene and cell (barcode) labels, upload or paste the link to it in the first field below: \"<b>matrix data file</b>\"</li>\n",
+    "        <li>If you have the three files from the 10X Genomics pipeline (matrix.mtx, genes.tsv, barcodes.tsv), upload them or provide a link to each file in the corresponding fields: <b>10x mtx data file, 10x gene name file, 10x barcodes file</b></li>\n",
+    "        <br>\n",
+    "        <b>NOTE: Do not use all four fields, either use the first one or the last three</b>\n",
+    "    </ol>\n",
     "</div>\n",
     "<br>\n",
     "<div class=\"well well-sm\">\n",
@@ -92,10 +95,28 @@
      },
      "show_code": false,
      "type": "uibuilder"
-    }
+    },
+    "nbtools": {
+     "description": "Load a raw count matrix for a single-cell RNA-seq experiment.\n\nIf data is a single matrix file, csv_filepath should be used\nand the other three variable names should be None. If data is in\n10x format (mtx, gene, barcode), csv_filepath should be None\nand the other three variables should be used correspondingly",
+     "name": "Setup Analysis",
+     "param_values": {
+      "bc_filepath": [],
+      "csv_filepath": [],
+      "gene_filepath": [],
+      "matrix_filepath": [],
+      "mtx_filepath": [],
+      "output_var": ""
+     },
+     "show_code": false,
+     "type": "uibuilder"
+    },
+    "scrolled": false
    },
    "outputs": [],
    "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
     "# Workaround for bug in GPNB 0.7.2\n",
     "from IPython.display import display, Javascript\n",
     "display(Javascript(\"\"\"\n",
@@ -138,19 +159,42 @@
     "    function_import='analysis.setup_analysis',\n",
     "    name='Setup Analysis',\n",
     "    parameters={\n",
-    "        'matrix_filepath': {\n",
+    "        'csv_filepath': {\n",
     "            'name': 'matrix data file',\n",
     "            'description': 'Provide your data file either as a URL or local file path. See above instructions for supported formats.',\n",
-    "            'default': 'https://github.com/genepattern/single_cell_clustering_notebook/raw/master/data/matrix.mtx',\n",
+    "            'default': None,\n",
     "            'type': 'file',\n",
-    "            'choices': {'2700 PBMCs from a Healthy Donor (example)': 'https://github.com/genepattern/single_cell_clustering_notebook/raw/master/data/matrix.mtx'},\n",
     "            'kinds': ['csv', 'xlsx', 'txt', 'tsv', 'tab', 'data', 'h5', 'h5ad', 'soft.gz', 'txt.gz', 'anndata', 'mtx'],\n",
+    "        },\n",
+    "        'mtx_filepath': {\n",
+    "            'name': '10x .mtx data file',\n",
+    "            'description': 'If you have data from 10X, upload or link your .mtx file here.',\n",
+    "            'default': 'https://github.com/genepattern/single_cell_clustering_notebook/raw/master/data/matrix.mtx',\n",
+    "            'choices': {'2700 PBMCs from a Healthy Donor (example) - mtx': 'https://github.com/genepattern/single_cell_clustering_notebook/raw/master/data/matrix.mtx'},\n",
+    "            'type': 'file',\n",
+    "            'kinds': ['mtx']\n",
+    "        },\n",
+    "        'gene_filepath': {\n",
+    "            'name': '10x gene name file',\n",
+    "            'description': 'If you have data from 10X, upload or link your genes.tsv file here',\n",
+    "            'default': 'https://github.com/genepattern/single_cell_clustering_notebook/raw/master/data/genes.tsv',\n",
+    "            'choices': {'2700 PBMCs from a Healthy Donor (example) - genes': 'https://github.com/genepattern/single_cell_clustering_notebook/raw/master/data/genes.tsv'},\n",
+    "            'type': 'file',\n",
+    "            'kinds': ['tsv']\n",
+    "        },\n",
+    "        'bc_filepath': {\n",
+    "            'name': '10x barcodes file',\n",
+    "            'description': 'If you have data from 10X, upload or link your barcodes.tsv file here',\n",
+    "            'default': 'https://github.com/genepattern/single_cell_clustering_notebook/raw/master/data/barcodes.tsv',\n",
+    "            'choices': {'2700 PBMCs from a Healthy Donor (example) - barcodes': 'https://github.com/genepattern/single_cell_clustering_notebook/raw/master/data/barcodes.tsv'},\n",
+    "            'type': 'file',\n",
+    "            'kinds': ['tsv']\n",
     "        },\n",
     "        'output_var': {\n",
     "            'hide': True\n",
     "        }\n",
     "    }\n",
-    ")"
+    ")\n"
    ]
   },
   {
@@ -191,6 +235,23 @@
       "min_n_counts": "0",
       "min_n_genes": "200",
       "min_percent_mito": "0",
+      "normalization_method": "LogNormalize",
+      "output_var": ""
+     },
+     "show_code": false,
+     "type": "uibuilder"
+    },
+    "nbtools": {
+     "description": "Perform cell quality control by evaluating quality metrics, normalizing counts, scaling, and correcting for effects of total counts per cell and the percentage of mitochondrial genes expressed. Also detect highly variable genes and perform linear dimensional reduction (PCA).",
+     "name": "Preprocess Counts",
+     "param_values": {
+      "max_n_counts": 5700,
+      "max_n_genes": 1700,
+      "max_percent_mito": 6,
+      "min_n_cells": 3,
+      "min_n_counts": 0,
+      "min_n_genes": 200,
+      "min_percent_mito": 0,
       "normalization_method": "LogNormalize",
       "output_var": ""
      },
@@ -298,6 +359,15 @@
     "genepattern": {
      "show_code": false,
      "type": "uibuilder"
+    },
+    "nbtools": {
+     "description": "This step outputs an interactive interface to cluster cells.",
+     "name": "Open Cell Clustering Interface",
+     "param_values": {
+      "output_var": ""
+     },
+     "show_code": false,
+     "type": "uibuilder"
     }
    },
    "outputs": [],
@@ -364,6 +434,15 @@
     },
     "genepattern": {
      "type": "uibuilder"
+    },
+    "nbtools": {
+     "description": "This step outputs an interactive interface to explore gene expression in clusters of cells.",
+     "name": "Open Visualize Cluster Markers Interface",
+     "param_values": {
+      "output_var": ""
+     },
+     "show_code": false,
+     "type": "uibuilder"
     }
    },
    "outputs": [],
@@ -427,6 +506,17 @@
      "param_values": {
       "path": "data/analysis"
      },
+     "type": "uibuilder"
+    },
+    "nbtools": {
+     "description": "Export data as a series of .csv files or compressed .hda5 file.",
+     "name": "Export Analysis Data",
+     "param_values": {
+      "h5ad": "false",
+      "output_var": "",
+      "path": "data/analysis"
+     },
+     "show_code": false,
      "type": "uibuilder"
     }
    },
@@ -494,9 +584,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.6",
    "language": "python",
-   "name": "python3"
+   "name": "python3.6"
   },
   "language_info": {
    "codemirror_mode": {
@@ -508,7 +598,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.7"
   },
   "varInspector": {
    "cols": {

--- a/singlecell.py
+++ b/singlecell.py
@@ -364,6 +364,8 @@ def _download_text_file(url):
     r = requests.get(url, stream=True)
     file_size = int(r.headers['Content-Length'])
     chunk_size = int(file_size / 50)
+    if chunk_size == 0:
+        chunk_size = int(file_size)
 
     progress_bar = FloatProgress(
         value=0,

--- a/singlecell.py
+++ b/singlecell.py
@@ -304,6 +304,10 @@ def _warning_message(message):
         '<div class="alert alert-warning" style="font-size:14px; line-height:20px;">{}</div>'.
         format(message))
 
+def _error_message(message):
+    return HTML(
+        '<div class="alert alert-danger" style="font-size:14px; line-height:20px;">{}</div>'.
+        format(message))
 
 def _create_export_button(figure, fname):
     # Default png
@@ -382,7 +386,6 @@ def _download_text_file(url):
 
     return filename
 
-
 class SingleCellAnalysis:
     """docstring for SingleCellAnalysis."""
 
@@ -392,46 +395,62 @@ class SingleCellAnalysis:
         mpl.rcParams['figure.dpi'] = 80
 
     # -------------------- SETUP ANALYSIS --------------------
-    def setup_analysis(self, matrix_filepath):
+    def setup_analysis(self, csv_filepath=None, mtx_filepath=None, 
+                        gene_filepath=None, bc_filepath=None):
         '''
         Load a raw count matrix for a single-cell RNA-seq experiment.
+
+        If data is a single matrix file, csv_filepath should be used
+        and the other three variable names should be None. If data is in
+        10x format (mtx, gene, barcode), csv_filepath should be None
+        and the other three variables should be used correspondingly
         '''
         # Hide FutureWarnings.
         warnings.simplefilter('ignore',
                               FutureWarning) if self.verbose else None
 
-        self._setup_analysis(matrix_filepath)
+        if not self._setup_analysis(csv_filepath, mtx_filepath, gene_filepath, bc_filepath):
+            return
         self._setup_analysis_ui()
 
         # Revert to default settings to show FutureWarnings.
         warnings.simplefilter('default',
                               FutureWarning) if self.verbose else None
 
-    def _setup_analysis(self, matrix_filepath):
-        # Downloads matrix if detects URL
-        local_matrix_filepath = matrix_filepath
-        if matrix_filepath.startswith('http'):
-            local_matrix_filepath = _download_text_file(matrix_filepath)
-        data = sc.read(local_matrix_filepath, cache=True).transpose()
+    def _setup_analysis(self, csv_filepath, mtx_filepath, gene_filepath,
+                        bc_filepath):
+        # Check for either one matrix file or all populated 10x fields, make
+        # sure user did not choose both or neither
+        paths_10x = [mtx_filepath, gene_filepath, bc_filepath]
+        use_csv = (csv_filepath != [])
+        use_10x = (paths_10x != [[], [], []])
+        if use_csv and use_10x:
+            display(_error_message("Can't use both single matrix file and 10X"))
+            return False
+        elif not use_csv and not use_10x:
+            display(_error_message("Must supply single matrix file or 10X files"))
+            return False
 
-        # Download genes.tsv and barcodes.tsv if matrix_filepath is URL
-        if matrix_filepath.endswith('.mtx'):
-            base_url = '/'.join(matrix_filepath.split('/')[:-1])
+        if use_csv:
+            local_csv_filepath = csv_filepath
+            if csv_filepath.startswith('http'):
+                local_csv_filepath = _download_text_file(csv_filepath)
+            data = sc.read(local_csv_filepath, cache=False).transpose()
 
-            # base_url refers to current directory if empty
-            if base_url == '':
-                base_url = '.'
+        elif use_10x:
+            local_mtx_filepath = mtx_filepath
+            local_gene_filepath = gene_filepath
+            local_bc_filepath = bc_filepath
 
-            barcodes_filepath = '/'.join([base_url, 'barcodes.tsv'])
-            genes_filepath = '/'.join([base_url, 'genes.tsv'])
-
-            # Download as necessary
-            if matrix_filepath.startswith('http'):
-                barcodes_filepath = _download_text_file(barcodes_filepath)
-                genes_filepath = _download_text_file(genes_filepath)
-
-            data.obs_names = np.genfromtxt(barcodes_filepath, dtype=str)
-            data.var_names = np.genfromtxt(genes_filepath, dtype=str)[:, 1]
+            if mtx_filepath.startswith('http'):
+                local_mtx_filepath = _download_text_file(mtx_filepath)
+            if gene_filepath.startswith('http'):
+                local_gene_filepath = _download_text_file(gene_filepath)
+            if bc_filepath.startswith('http'):
+                local_bc_filepath = _download_text_file(bc_filepath)
+            data = sc.read(local_mtx_filepath, cache=False).transpose()
+            data.obs_names = np.genfromtxt(local_bc_filepath, dtype=str)
+            data.var_names = np.genfromtxt(local_gene_filepath, dtype=str)[:,1]
 
         # This is needed to setup the "n_genes" column in data.obs.
         sc.pp.filter_cells(data, min_genes=0)
@@ -448,6 +467,7 @@ class SingleCellAnalysis:
         data.obs['n_counts'] = np.sum(data.X, axis=1)
         data.is_log = False
         self.data = data
+        return True
 
     def _setup_analysis_ui(self):
         measures = pd.DataFrame([


### PR DESCRIPTION
This pull request addresses the ticket "Enable mtx/barcode/gene upload". I rewrote the file input UIBuilder to have four input fields. The first one should be used if the user has a single file with gene and cell labels in the first column and row respectively. The last three should be used if the user has a `matrix.mtx`, `genes.tsv`, and `barcodes.tsv` file from the 10X pipeline. These fields should be used in a mutually exclusive manner, and I added an HTML alert if the user populates all four fields or otherwise doesn't use them correctly. 

Also included are updated notebook documentation to reflect these changes, a new wrapper for displaying "alert-danger" style errors, and modifications to the some setup functions to make them return boolean flags to enable the previously-mentioned error checking without printing tracebacks.

For testing I used the example in this repo as well as [this single-matrix file](https://drive.google.com/file/d/1w3fGNO7FYCX8qhjgnKXXoKT46pexJbQF/view?usp=sharing) from one of Seurat's vignettes.